### PR TITLE
Allow for service name to be specified

### DIFF
--- a/helm/prometheus-kafka-adapter/templates/deployment.yaml
+++ b/helm/prometheus-kafka-adapter/templates/deployment.yaml
@@ -36,24 +36,24 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: KAFKA_BROKER_LIST
-            value: {{ tpl .Values.env.KAFKA_BROKER_LIST . }} # may want customizable service references
+            value: {{ tpl .Values.environment.KAFKA_BROKER_LIST . }} # may want customizable service references
           - name: KAFKA_TOPIC
-            value: {{ tpl .Values.env.KAFKA_TOPIC . }}
+            value: {{ tpl .Values.environment.KAFKA_TOPIC . }}
           - name: KAFKA_COMPRESSION
-            value: {{ .Values.env.KAFKA_COMPRESSION | quote }}
+            value: {{ .Values.environment.KAFKA_COMPRESSION | quote }}
           - name: KAFKA_BATCH_NUM_MESSAGES
-            value: {{ .Values.env.KAFKA_BATCH_NUM_MESSAGES | quote }}
+            value: {{ .Values.environment.KAFKA_BATCH_NUM_MESSAGES | quote }}
           - name: SERIALIZATION_FORMAT
-            value: {{ .Values.env.SERIALIZATION_FORMAT | quote }}
+            value: {{ .Values.environment.SERIALIZATION_FORMAT | quote }}
           - name: PORT
-            value: {{ .Values.env.PORT | quote }}
-          {{- if .Values.env.BASIC_AUTH_USERNAME }}
+            value: {{ .Values.environment.PORT | quote }}
+          {{- if .Values.environment.BASIC_AUTH_USERNAME }}
           - name: BASIC_AUTH_USERNAME
             valueFrom:
               secretKeyRef:
                 name: {{ include "prometheus-kafka-adapter.fullname" . }}
                 key: BASIC_AUTH_USERNAME
-          {{- end }}{{- if .Values.env.BASIC_AUTH_PASSWORD }}
+          {{- end }}{{- if .Values.environment.BASIC_AUTH_PASSWORD }}
           - name: BASIC_AUTH_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -61,14 +61,14 @@ spec:
                 key: BASIC_AUTH_PASSWORD
           {{- end }}
           - name: LOG_LEVEL
-            value: {{ .Values.env.LOG_LEVEL | quote }}
+            value: {{ .Values.environment.LOG_LEVEL | quote }}
           - name: GIN_MODE
-            value: {{ .Values.env.GIN_MODE | quote }}
+            value: {{ .Values.environment.GIN_MODE | quote }}
           - name: KAFKA_TLS_CLIENT_CERT_FILE
-            value: {{ .Values.env.KAFKA_TLS_CLIENT_CERT_FILE | quote }}
+            value: {{ .Values.environment.KAFKA_TLS_CLIENT_CERT_FILE | quote }}
           - name: KAFKA_TLS_CLIENT_KEY_FILE
-            value: {{ .Values.env.KAFKA_TLS_CLIENT_KEY_FILE | quote }}
-          {{- if .Values.env.KAFKA_TLS_CLIENT_KEY_PASS }}
+            value: {{ .Values.environment.KAFKA_TLS_CLIENT_KEY_FILE | quote }}
+          {{- if .Values.environment.KAFKA_TLS_CLIENT_KEY_PASS }}
           - name: KAFKA_TLS_CLIENT_KEY_PASS
             valueFrom:
               secretKeyRef:
@@ -76,10 +76,10 @@ spec:
                 key: KAFKA_TLS_CLIENT_KEY_PASS
           {{- end }}
           - name: KAFKA_TLS_CA_CERT_FILE
-            value: {{ .Values.env.KAFKA_TLS_CA_CERT_FILE | quote }}
+            value: {{ .Values.environment.KAFKA_TLS_CA_CERT_FILE | quote }}
           ports:
             - name: http
-              containerPort: {{ .Values.env.PORT }}
+              containerPort: {{ .Values.environment.PORT }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/helm/prometheus-kafka-adapter/templates/secrets.yaml
+++ b/helm/prometheus-kafka-adapter/templates/secrets.yaml
@@ -7,10 +7,10 @@ metadata:
 {{ include "prometheus-kafka-adapter.labels" . | indent 4 }}
 type: Opaque
 data:
-{{- if .Values.env.KAFKA_TLS_CLIENT_KEY_PASS }}
-  KAFKA_TLS_CLIENT_KEY_PASS: {{ .Values.env.KAFKA_TLS_CLIENT_KEY_PASS | b64enc }}
-{{- end }}{{- if .Values.env.BASIC_AUTH_USERNAME }}
-  BASIC_AUTH_USERNAME: {{ .Values.env.BASIC_AUTH_USERNAME | b64enc }}
-{{- end }}{{- if .Values.env.BASIC_AUTH_PASSWORD }}
-  BASIC_AUTH_PASSWORD: {{ .Values.env.BASIC_AUTH_PASSWORD | b64enc }}
+{{- if .Values.environment.KAFKA_TLS_CLIENT_KEY_PASS }}
+  KAFKA_TLS_CLIENT_KEY_PASS: {{ .Values.environment.KAFKA_TLS_CLIENT_KEY_PASS | b64enc }}
+{{- end }}{{- if .Values.environment.BASIC_AUTH_USERNAME }}
+  BASIC_AUTH_USERNAME: {{ .Values.environment.BASIC_AUTH_USERNAME | b64enc }}
+{{- end }}{{- if .Values.environment.BASIC_AUTH_PASSWORD }}
+  BASIC_AUTH_PASSWORD: {{ .Values.environment.BASIC_AUTH_PASSWORD | b64enc }}
 {{- end }}

--- a/helm/prometheus-kafka-adapter/templates/service.yaml
+++ b/helm/prometheus-kafka-adapter/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "prometheus-kafka-adapter.fullname" . }}
+  name: {{ tpl .Values.service.name . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "prometheus-kafka-adapter.labels" . | indent 4 }}

--- a/helm/prometheus-kafka-adapter/templates/service.yaml
+++ b/helm/prometheus-kafka-adapter/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ tpl .Values.service.name . }}
+  name: {{ default (include "prometheus-kafka-adapter.fullname" . ) .Values.service.name }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "prometheus-kafka-adapter.labels" . | indent 4 }}

--- a/helm/prometheus-kafka-adapter/values.yaml
+++ b/helm/prometheus-kafka-adapter/values.yaml
@@ -19,7 +19,7 @@ pod:
     prometheus.io/port: "8080"
 
 
-env:
+environment:
   # defines kafka endpoint and port, defaults to kafka:9092.
   KAFKA_BROKER_LIST: ""
   # defines kafka topic to be used, defaults to metrics.
@@ -68,7 +68,6 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
-  name: "{{ include \"prometheus-kafka-adapter.fullname\" . }}"
   type: ClusterIP
   port: 80
   annotations: {}

--- a/helm/prometheus-kafka-adapter/values.yaml
+++ b/helm/prometheus-kafka-adapter/values.yaml
@@ -68,6 +68,7 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  name: "{{ include \"prometheus-kafka-adapter.fullname\" . }}"
   type: ClusterIP
   port: 80
   annotations: {}


### PR DESCRIPTION
This minor change allows for the service name to be overridden so that it isn't strictly dependent on the chart deployment process.