### PR TITLE
Add option for internal queue length

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Prometheus-kafka-adapter listens for metrics coming from Prometheus and sends th
 - `KAFKA_BROKER_LIST`: defines kafka endpoint and port, defaults to `kafka:9092`.
 - `KAFKA_TOPIC`: defines kafka topic to be used, defaults to `metrics`.
 - `KAFKA_COMPRESSION`: defines the compression type to be used, defaults to `none`.
+- `KAFKA_QUEUE_BUFFERING_MAX_MESSAGES`: defines the maximum number of messages allowed on the producer queue, defaults to `100000`.
 - `KAFKA_BATCH_NUM_MESSAGES`: defines the number of messages to batch write, defaults to `10000`.
 - `SERIALIZATION_FORMAT`: defines the serialization format, can be `json`, `avro-json`, defaults to `json`.
 - `PORT`: defines http port to listen, defaults to `8080`, used directly by [gin](https://github.com/gin-gonic/gin).
@@ -53,7 +54,7 @@ Prometheus-kafka-adapter listens for metrics coming from Prometheus and sends th
 - `LOG_LEVEL`: defines log level for [`logrus`](https://github.com/sirupsen/logrus), can be `debug`, `info`, `warn`, `error`, `fatal` or `panic`, defaults to `info`.
 - `GIN_MODE`: manage [gin](https://github.com/gin-gonic/gin) debug logging, can be `debug` or `release`.
 
-To connect to Kafka over SSL define the following additonal environment variables:
+To connect to Kafka over SSL define the following additional environment variables:
 
 - `KAFKA_SSL_CLIENT_CERT_FILE`: Kafka SSL client certificate file, defaults to `""`
 - `KAFKA_SSL_CLIENT_KEY_FILE`: Kafka SSL client certificate key file, defaults to `""`

--- a/config.go
+++ b/config.go
@@ -18,7 +18,6 @@ import (
 	"os"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -32,6 +33,7 @@ var (
 		Partition: kafka.PartitionAny,
 	}
 	kafkaCompression       = "none"
+	kafkaBufferMaxMessages = "100000"
 	kafkaBatchNumMessages  = "10000"
 	kafkaSslClientCertFile = ""
 	kafkaSslClientKeyFile  = ""
@@ -73,6 +75,10 @@ func init() {
 
 	if value := os.Getenv("KAFKA_COMPRESSION"); value != "" {
 		kafkaCompression = value
+	}
+
+	if value := os.Getenv("KAFKA_QUEUE_BUFFERING_MAX_MESSAGES"); value != "" {
+		kafkaBufferMaxMessages = value
 	}
 
 	if value := os.Getenv("KAFKA_BATCH_NUM_MESSAGES"); value != "" {

--- a/helm/prometheus-kafka-adapter/templates/deployment.yaml
+++ b/helm/prometheus-kafka-adapter/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
             value: {{ tpl .Values.environment.KAFKA_TOPIC . }}
           - name: KAFKA_COMPRESSION
             value: {{ .Values.environment.KAFKA_COMPRESSION | quote }}
+          - name: KAFKA_QUEUE_BUFFERING_MAX_MESSAGES
+            value: {{ .Values.environment.KAFKA_QUEUE_BUFFERING_MAX_MESSAGES | quote }}
           - name: KAFKA_BATCH_NUM_MESSAGES
             value: {{ .Values.environment.KAFKA_BATCH_NUM_MESSAGES | quote }}
           - name: SERIALIZATION_FORMAT

--- a/helm/prometheus-kafka-adapter/values.yaml
+++ b/helm/prometheus-kafka-adapter/values.yaml
@@ -32,6 +32,8 @@ environment:
   KAFKA_TOPIC: ""
   # defines the compression type to be used, defaults to none.
   KAFKA_COMPRESSION:
+  # sets the maximum number of messages allowed on the producer queue, defaults to 100000
+  KAFKA_QUEUE_BUFFERING_MAX_MESSAGES:
   # defines the number of messages to batch write, defaults to 10000.
   KAFKA_BATCH_NUM_MESSAGES:
   # defines the serialization format, can be json, avro-json, defaults to json.

--- a/main.go
+++ b/main.go
@@ -29,15 +29,16 @@ func main() {
 	log.Info("creating kafka producer")
 
 	kafkaConfig := kafka.ConfigMap{
-		"bootstrap.servers":        kafkaBrokerList,
-		"compression.codec":        kafkaCompression,
-		"batch.num.messages":       kafkaBatchNumMessages,
-		"go.batch.producer":        true,                   // Enable batch producer (for increased performance).
-		"go.delivery.reports":      false,                  // per-message delivery reports to the Events() channel
-		"ssl.ca.location":          kafkaSslCACertFile,     // CA certificate file for verifying the broker's certificate.
-		"ssl.certificate.location": kafkaSslClientCertFile, // Client's certificate
-		"ssl.key.location":         kafkaSslClientKeyFile,  // Client's key
-		"ssl.key.password":         kafkaSslClientKeyPass,  // Key password, if any.
+		"bootstrap.servers":            kafkaBrokerList,
+		"compression.codec":            kafkaCompression,
+		"batch.num.messages":           kafkaBatchNumMessages,
+		"queue.buffering.max.messages": kafkaBufferMaxMessages,
+		"go.batch.producer":            true,                   // Enable batch producer (for increased performance).
+		"go.delivery.reports":          false,                  // per-message delivery reports to the Events() channel
+		"ssl.ca.location":              kafkaSslCACertFile,     // CA certificate file for verifying the broker's certificate.
+		"ssl.certificate.location":     kafkaSslClientCertFile, // Client's certificate
+		"ssl.key.location":             kafkaSslClientKeyFile,  // Client's key
+		"ssl.key.password":             kafkaSslClientKeyPass,  // Key password, if any.
 	}
 
 	if kafkaSslClientCertFile != "" && kafkaSslClientKeyFile != "" && kafkaSslCACertFile != "" {


### PR DESCRIPTION
Because of the batch nature and size of the workload, we've been seeing errors about the local queue being full
```
"error":"Local: Queue full", "level":"error","msg":"couldn’t produce message in kafka"
```
This change allows the `queue.buffering.max.messages` field of the underlying library to be set. (https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
This shouldn't affect throughput necessarily, but should allow for the batchier nature of the workload we have to work without errors.