### PR TITLE
Adds metric collection for internal queue length

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ func main() {
 
 	r.Use(ginrus.Ginrus(logrus.StandardLogger(), time.RFC3339, true), gin.Recovery())
 
+	initMetrics(producer)
 	r.GET("/metrics", gin.WrapH(prometheus.UninstrumentedHandler()))
 
 	if basicauth {

--- a/metrics.go
+++ b/metrics.go
@@ -17,7 +17,6 @@ package main
 import (
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -26,32 +25,15 @@ var (
 			Name: "http_requests_total",
 			Help: "Count of all http requests",
 		})
-	queueSizeDesc = prometheus.NewDesc(
-		"kafka_queue_size",
-		"Queue size for metrics sent to Kafka",
-		[]string{},
-		prometheus.Labels{},
-	)
 )
 
-type queueLenCollector struct {
-	producer *kafka.Producer
-}
-
-func (queueLenCollector) Describe(descChan chan<- *prometheus.Desc) {
-	descChan <- queueSizeDesc
-}
-
-func (qlc queueLenCollector) Collect(metricChan chan<- prometheus.Metric) {
-	qLen := float64(qlc.producer.Len())
-	met, err := prometheus.NewConstMetric(queueSizeDesc, prometheus.GaugeValue, qLen)
-	if err != nil {
-		logrus.WithError(err).Error("Error collecting kafka_queue_size metric")
-	}
-	metricChan <- met
-}
-
 func initMetrics(producer *kafka.Producer) {
+	prometheus.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "kafka_queue_size",
+			Help: "Queue size for metrics sent to Kafka",
+		},
+		func() float64 { return float64(producer.Len()) },
+	))
 	prometheus.MustRegister(httpRequestsTotal)
-	prometheus.MustRegister(&queueLenCollector{producer: producer})
 }

--- a/metrics.go
+++ b/metrics.go
@@ -14,22 +14,44 @@
 
 package main
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
 
 var (
-	queueSize = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "kafka_queue_size",
-			Help: "Queue size for metrics sent to Kafka",
-		})
 	httpRequestsTotal = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "http_requests_total",
 			Help: "Count of all http requests",
 		})
+	queueSizeDesc = prometheus.NewDesc(
+		"kafka_queue_size",
+		"Queue size for metrics sent to Kafka",
+		[]string{},
+		prometheus.Labels{},
+	)
 )
 
-func init() {
-	prometheus.MustRegister(queueSize)
+type queueLenCollector struct {
+	producer *kafka.Producer
+}
+
+func (queueLenCollector) Describe(descChan chan<- *prometheus.Desc) {
+	descChan <- queueSizeDesc
+}
+
+func (qlc queueLenCollector) Collect(metricChan chan<- prometheus.Metric) {
+	qLen := float64(qlc.producer.Len())
+	met, err := prometheus.NewConstMetric(queueSizeDesc, prometheus.GaugeValue, qLen)
+	if err != nil {
+		logrus.WithError(err).Error("Error collecting kafka_queue_size metric")
+	}
+	metricChan <- met
+}
+
+func initMetrics(producer *kafka.Producer) {
 	prometheus.MustRegister(httpRequestsTotal)
+	prometheus.MustRegister(&queueLenCollector{producer: producer})
 }


### PR DESCRIPTION
The internal queue_size metric was never implemented (it has been removed upstream now). This change implements it, allowing us to monitor whether the queue is persistently full, or transiently filling (we've seen errors about the local queue filling).