### PR TITLE
always sync topic metadata

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,10 +73,8 @@ func main() {
 		logrus.WithError(err).Fatal("couldn't create kafka producer")
 	}
 
-	if kafkaPartitionLabels != nil {
-		if err := syncTopicMetadata(ctx, producer); err != nil {
-			logrus.WithError(err).Fatal("couldn't fetch topic metadata")
-		}
+	if err := syncTopicMetadata(ctx, producer); err != nil {
+		logrus.WithError(err).Fatal("couldn't fetch topic metadata")
 	}
 
 	r := gin.New()


### PR DESCRIPTION
Without this, when `KAFKA_PARTITION_LABELS` is not configured, we get an error reading the metadata map on every write. Since it defaults to using all labels (rather than defaulting to disabled), the metadata always needs to be loaded.