### PR TITLE
update prometheus-kafka-adapter 1.8.0 to 1.9.1

### DIFF
--- a/helm/prometheus-kafka-adapter/values.yaml
+++ b/helm/prometheus-kafka-adapter/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: telefonica/prometheus-kafka-adapter
-  tag: 1.8.0
+  tag: 1.9.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/schemas/metric.avsc
+++ b/schemas/metric.avsc
@@ -2,7 +2,7 @@
     "namespace": "io.prometheus",
     "type": "record",
     "name": "Metric",
-    "doc:" : "A basic schema for representing Prometheus metrics",
+    "doc" : "A basic schema for representing Prometheus metrics",
     "fields": [
         {"name": "timestamp", "type": "string"},
         {"name": "value", "type": "string"},


### PR DESCRIPTION
`1.9.1` is the latest of prometheus-kafka-adapter.
Reference -->  https://hub.docker.com/r/telefonica/prometheus-kafka-adapter/tags