### PR TITLE
Sort partition-hash labels for deterministic Kafka topic

### DIFF
--- a/serializers.go
+++ b/serializers.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"sort"
 	"strconv"
 	"time"
 
@@ -123,8 +124,15 @@ func topic(labels map[string]string) string {
 
 	// hashes all labels when no specific labels are configured
 	if kafkaPartitionLabels == nil {
-		for k, v := range labels {
-			if _, err := buf2.WriteString(k + v); err != nil {
+		// sort keys so the partition hash is deterministic regardless of
+		// Go's randomized map iteration order
+		keys := make([]string, 0, len(labels))
+		for k := range labels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if _, err := buf2.WriteString(k + labels[k]); err != nil {
 				return ""
 			}
 		}


### PR DESCRIPTION
## Problem

`topic()` builds the partition-hash suffix by ranging directly over the `labels` map. Go randomizes map iteration order, so the generated topic key is non-deterministic.

Consequences:
- **Flaky tests** — `TestSerializeToAvro` and `TestSerializeToJSON` assert against a hard-coded key (`metrics|__name__foolabelfoolabel-bar`). With two labels the suffix order flips run-to-run, so the lookup intermittently misses and the tests fail with:
  ```
  output map does not contain expected key
  "[]" should have 2 item(s), but has 0
  ```
- **Runtime** — when `KAFKA_PARTITION_LABELS` is unset, samples from the same series could hash to different topic keys across calls.

## Fix

Sort the label keys before concatenating them into the partition hash, so the topic key is stable regardless of map iteration order.

```go
keys := make([]string, 0, len(labels))
for k := range labels {
    keys = append(keys, k)
}
sort.Strings(keys)
for _, k := range keys {
    buf2.WriteString(k + labels[k])
}
```

## Testing

- `go test ./... -count=30` — green (previously failed intermittently; reproduced the exact CI failure on the old code)
- `go vet ./...` and `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
